### PR TITLE
Add square picture with label and add colors to tailwind config

### DIFF
--- a/frontend/src/Components/SquarePicture.tsx
+++ b/frontend/src/Components/SquarePicture.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface SquarePictureWithLabelProps {
+  label: string;
+  imageUrl: string;
+}
+
+function SquarePictureWithLabel({ label, imageUrl }: SquarePictureWithLabelProps) {
+  return (
+    <div className="flex flex-col items-center">
+      {/* Square image */}
+      <img 
+        src={imageUrl}
+        alt={label}
+        className="CircularPicture shadow-md rounded-lg object-cover"
+      />
+      
+      {/* Label */}
+      <p className="mt-2 text-center text-lg font-semibold">{label}</p>
+    </div>
+  );
+}
+
+export default SquarePictureWithLabel;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,15 @@ module.exports = {
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        periwinkle: '#b3c2f2ff',
+        slateBlue: '#735cddff',
+        mauveine: '#9000b3ff',
+        purple: '#7e007bff',
+        blackBean: '#37000aff',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
1 - A square picture with a label, intended to be used in the Events panel

2- I added the colors from our color palette to the tailwind config so we can use them with tailwind