### PR TITLE
Fixed wrong column name in updateUserLocation

### DIFF
--- a/backend/src/Models/Users/user.model.ts
+++ b/backend/src/Models/Users/user.model.ts
@@ -60,7 +60,7 @@ export const updateUserLocation = async (userEmail: string, latitude: number, lo
                 longitude: longitude,
                 locationName: newLocationName
             })
-            .returning(['id', 'username', 'userPostIds', 'created_at', 'latitude', 'longitude', 'email', 'newLocationName', 'friends']);
+            .returning(['id', 'username', 'userPostIds', 'created_at', 'latitude', 'longitude', 'email', 'locationName', 'friends']);
 
         console.log(`Successfully updated location of user ${foundUser[0].username}`);
 


### PR DESCRIPTION
One of the columns in updateUserLocation had the wrong name and was causing errors when I tried updating via postman